### PR TITLE
fix order in sender field

### DIFF
--- a/lib/cxml/sender.rb
+++ b/lib/cxml/sender.rb
@@ -12,8 +12,8 @@ module CXML
 
     def render(node)
       node.Sender do |n|
-        n.UserAgent(@user_agent)
         @credential.render(n)
+        n.UserAgent(@user_agent)
       end
       node
     end

--- a/spec/sender_spec.rb
+++ b/spec/sender_spec.rb
@@ -25,7 +25,6 @@ describe CXML::Sender do
         </Sender>
         EOF
       )
-      
     end
   end
 end

--- a/spec/sender_spec.rb
+++ b/spec/sender_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe CXML::Sender do
+  describe "#render" do
+    it "returns cxml sender field" do
+      builder = CXML.builder
+      sender_credential = CXML::Credential.new
+      sender_credential.domain = 'sender_domain'
+      sender_credential.identity = 'sender_id'
+      sender_credential.shared_secret = "123456"
+
+      sender = described_class.new      
+      sender.user_agent = 'Alphasights LTD'
+      sender.credential = sender_credential
+
+      expect(sender.render(builder).to_xml).to eq(
+'<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.020/InvoiceDetail.dtd">
+<Sender>
+  <Credential domain="sender_domain">
+    <Identity>sender_id</Identity>
+    <SharedSecret>123456</SharedSecret>
+  </Credential>
+  <UserAgent>Alphasights LTD</UserAgent>
+</Sender>
+')
+      
+    end
+  end
+end

--- a/spec/sender_spec.rb
+++ b/spec/sender_spec.rb
@@ -13,17 +13,18 @@ describe CXML::Sender do
       sender.user_agent = 'Alphasights LTD'
       sender.credential = sender_credential
 
-      expect(sender.render(builder).to_xml).to eq(
-'<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.020/InvoiceDetail.dtd">
-<Sender>
-  <Credential domain="sender_domain">
-    <Identity>sender_id</Identity>
-    <SharedSecret>123456</SharedSecret>
-  </Credential>
-  <UserAgent>Alphasights LTD</UserAgent>
-</Sender>
-')
+      expect(sender.render(builder).to_xml).to eq(<<~EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.020/InvoiceDetail.dtd">
+        <Sender>
+          <Credential domain="sender_domain">
+            <Identity>sender_id</Identity>
+            <SharedSecret>123456</SharedSecret>
+          </Credential>
+          <UserAgent>Alphasights LTD</UserAgent>
+        </Sender>
+        EOF
+      )
       
     end
   end


### PR DESCRIPTION
order is important. if you move the useragent subfield above the credential subfield in Sender, the query fails in postman.
