### PR TITLE
Remove method to instantiate items

### DIFF
--- a/lib/cxml/invoice_detail_request/order.rb
+++ b/lib/cxml/invoice_detail_request/order.rb
@@ -6,7 +6,9 @@ module CXML
       def initialize(data={})
         if data.kind_of?(Hash) && !data.empty?
           @payload_id = data[:payload_id]
-          self.items = data[:items]
+          @items = data[:items].map do |args|
+            CXML::InvoiceDetailRequest::ServiceItem.new(args)
+          end
         end
       end
 
@@ -23,14 +25,6 @@ module CXML
           end
         end
         node
-      end
-
-      private
-
-      def items=(items)
-        @items = items.map do|args|
-          CXML::InvoiceDetailRequest::ServiceItem.new(args)
-        end
       end
     end
   end


### PR DESCRIPTION
It's more consistent if we do it manually and pass it in, just like we do anywhere else in the code
