### PR TITLE
add remit to field

### DIFF
--- a/lib/cxml/invoice_detail_request/contact.rb
+++ b/lib/cxml/invoice_detail_request/contact.rb
@@ -1,20 +1,25 @@
+require 'byebug'
+
 module CXML
   module InvoiceDetailRequest
     class Contact
-      attr_accessor :role, :name, :language, :postal_address, :email
+      attr_accessor :role, :name, :language, :postal_address, :email, :address_id
 
       def initialize(data={})
         if data.kind_of?(Hash) && !data.empty?
           @role = data[:role]
           @name = data[:name]
           @email = data[:email]
+          @address_id = data[:address_id]
           @postal_address =
             CXML::InvoiceDetailRequest::PostalAddress.new(data[:postal_address])
         end
       end
 
       def render(node)
-        node.Contact('role' => role) do |c|
+        contact_args = { 'role' => role }
+        contact_args = contact_args.merge('addressID' => address_id) if address_id
+        node.Contact(contact_args) do |c|
           c.Name(name, 'xml:lang' => 'en')
           postal_address.render(c) if postal_address
           c.Email(email) if email

--- a/lib/cxml/invoice_detail_request/contact.rb
+++ b/lib/cxml/invoice_detail_request/contact.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module CXML
   module InvoiceDetailRequest
     class Contact

--- a/lib/cxml/invoice_detail_request/header.rb
+++ b/lib/cxml/invoice_detail_request/header.rb
@@ -1,7 +1,7 @@
 module CXML
   module InvoiceDetailRequest
     class Header
-      attr_accessor :invoice_id, :operation, :purpose, :invoice_date, :from, :bill_to,
+      attr_accessor :invoice_id, :operation, :purpose, :invoice_date, :from, :bill_to, :remit_to,
         :payment_term, :primary_study_contact, :case_code, :vatin, :comments, :invoice_type
 
       def initialize(data={})
@@ -12,6 +12,7 @@ module CXML
           @invoice_date = data[:invoice_date]
           @from = CXML::InvoiceDetailRequest::Contact.new(data[:from])
           @bill_to = CXML::InvoiceDetailRequest::Contact.new(data[:bill_to])
+          @remit_to = CXML::InvoiceDetailRequest::Contact.new(data[:remit_to])
           @payment_term = data[:payment_term]
           @comments = data[:comments]
           @primary_study_contact = data[:primary_study_contact]
@@ -32,6 +33,7 @@ module CXML
           h.InvoiceDetailLineIndicator
           h.InvoicePartner { |n| from.render(n) }
           h.InvoicePartner { |n| bill_to.render(n) }
+          h.InvoicePartner { |n| remit_to.render(n) }
           h.PaymentTerm('payInNumberOfDays' => payment_term)
           h.Comments(comments, 'xml:lang' => 'en') if comments
           h.Extrinsic(primary_study_contact, 'name' => 'Primary Study Contact') if primary_study_contact

--- a/spec/invoice_details_request/header_spec.rb
+++ b/spec/invoice_details_request/header_spec.rb
@@ -23,6 +23,7 @@ module CXML
           invoice_date: '2016-10-15T15:48:51-00:00',
           from: from_attrs,
           bill_to: from_attrs.merge(role: 'billTo', name: 'Bill', email: 'bill@gmail.com'),
+          remit_to: from_attrs.merge(role: 'remitTo', name: 'Bill', email: 'bill@gmail.com', address_id: '123'),
           payment_term: 30,
           primary_study_contact: 'John Doe',
           case_code: 'A1',
@@ -50,6 +51,18 @@ module CXML
             </InvoicePartner>
             <InvoicePartner>
               <Contact role="billTo">
+                <Name xml:lang="en">Bill</Name>
+                <PostalAddress>
+                  <Street>1st Street</Street>
+                  <City>Denver</City>
+                  <PostalCode>1234</PostalCode>
+                  <Country isoCountryCode="US">US</Country>
+                </PostalAddress>
+                <Email>bill@gmail.com</Email>
+              </Contact>
+            </InvoicePartner>
+            <InvoicePartner>
+              <Contact role="remitTo" addressID="123">
                 <Name xml:lang="en">Bill</Name>
                 <PostalAddress>
                   <Street>1st Street</Street>

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -25,6 +25,7 @@ describe CXML::Request do
         invoice_date: '2016-10-15T15:48:51-00:00',
         from: from_attrs,
         bill_to: from_attrs.merge(role: 'billTo', name: 'Bill', email: 'bill@gmail.com'),
+        remit_to: from_attrs.merge(role: 'remitTo', name: 'Bill', email: 'bill@gmail.com', address_id: '123'),
         payment_term: 30,
         primary_study_contact: 'John Doe',
         case_code: 'A1',
@@ -90,6 +91,18 @@ describe CXML::Request do
             </InvoicePartner>
             <InvoicePartner>
               <Contact role="billTo">
+                <Name xml:lang="en">Bill</Name>
+                <PostalAddress>
+                  <Street>1st Street</Street>
+                  <City>Denver</City>
+                  <PostalCode>1234</PostalCode>
+                  <Country isoCountryCode="US">US</Country>
+                </PostalAddress>
+                <Email>bill@gmail.com</Email>
+              </Contact>
+            </InvoicePartner>
+            <InvoicePartner>
+              <Contact role="remitTo" addressID="123">
                 <Name xml:lang="en">Bill</Name>
                 <PostalAddress>
                   <Street>1st Street</Street>


### PR DESCRIPTION
This adds support for the remitTo invoice partner. This invoice partner requires an address_id field. 