### PR TITLE
provide option for use of multiple distributions

### DIFF
--- a/lib/cxml/invoice_detail_request/service_item.rb
+++ b/lib/cxml/invoice_detail_request/service_item.rb
@@ -9,7 +9,7 @@ module CXML
           @description = data[:description]
           @amount = data[:amount]
           @currency = data[:currency]
-          @distributions = (data[:distributions]||[]).map do |args|
+          @distributions = data[:distributions].to_a.map do |args|
             CXML::InvoiceDetailRequest::Distribution.new(args)
           end
         end

--- a/lib/cxml/invoice_detail_request/service_item.rb
+++ b/lib/cxml/invoice_detail_request/service_item.rb
@@ -1,7 +1,7 @@
 module CXML
   module InvoiceDetailRequest
     class ServiceItem
-      attr_accessor :invoice_line_number, :reference_date, :description, :amount, :currency, :distribution
+      attr_accessor :invoice_line_number, :reference_date, :description, :amount, :currency, :distributions
       def initialize(data={})
         if data.kind_of?(Hash) && !data.empty?
           @invoice_line_number = data[:invoice_line_number]
@@ -9,7 +9,9 @@ module CXML
           @description = data[:description]
           @amount = data[:amount]
           @currency = data[:currency]
-          @distribution = CXML::InvoiceDetailRequest::Distribution.new(data[:distribution]) if data[:distribution]
+          @distributions = (data[:distributions]||[]).map do |args|
+            CXML::InvoiceDetailRequest::Distribution.new(args)
+          end
         end
       end
 
@@ -23,7 +25,9 @@ module CXML
             si.SubtotalAmount do |sa|
               sa.Money(amount, 'currency' => currency)
             end
-            distribution.render(si) if distribution
+            distributions.each do |distribution|
+              distribution.render(si)
+            end
           end
         node
       end

--- a/spec/invoice_details_request/service_item_spec.rb
+++ b/spec/invoice_details_request/service_item_spec.rb
@@ -23,7 +23,7 @@ module CXML
           description: 'this is a description',
           amount: 400,
           currency: 'GBP',
-          distribution: distribution_attrs
+          distributions: [distribution_attrs]
         }
 
         service_item = described_class.new(item_attrs)

--- a/spec/invoice_details_request/service_item_spec.rb
+++ b/spec/invoice_details_request/service_item_spec.rb
@@ -10,11 +10,18 @@ module CXML
           { id: 405, name: 'Name', description: 'Description' },
           { id: 406, name: 'Other Name', description: 'Other Description' }
         ]
-        distribution_attrs = {
+        distribution_attrs_1 = {
           accounting_name: 'UK Account',
           accounting_segments: segments_attrs,
           charge_amount: 200,
           charge_currency: 'GBP'
+        }
+
+        distribution_attrs_2 = {
+          accounting_name: 'US Account',
+          accounting_segments: segments_attrs,
+          charge_amount: 200,
+          charge_currency: 'USD'
         }
 
         item_attrs = {
@@ -23,7 +30,7 @@ module CXML
           description: 'this is a description',
           amount: 400,
           currency: 'GBP',
-          distributions: [distribution_attrs]
+          distributions: [distribution_attrs_1, distribution_attrs_2]
         }
 
         service_item = described_class.new(item_attrs)
@@ -51,6 +58,21 @@ module CXML
               </Accounting>
               <Charge>
                 <Money currency="GBP">200</Money>
+              </Charge>
+            </Distribution>
+            <Distribution>
+              <Accounting name="US Account">
+                <AccountingSegment id="405">
+                  <Name xml:lang="en">Name</Name>
+                  <Description xml:lang="en">Description</Description>
+                </AccountingSegment>
+                <AccountingSegment id="406">
+                  <Name xml:lang="en">Other Name</Name>
+                  <Description xml:lang="en">Other Description</Description>
+                </AccountingSegment>
+              </Accounting>
+              <Charge>
+                <Money currency="USD">200</Money>
               </Charge>
             </Distribution>
           </InvoiceDetailServiceItem>


### PR DESCRIPTION
reference: #17 

In the example provided in [the coupa docs](https://success.coupa.com/Suppliers/Integration_Resources/Sample_Invoices/Sample_cXML_Invoice_with_Billing_Account_Distributions) a line item can be assigned multiple distributions. This PR provides the option for multiple distribution nodes as such.