### PR TITLE
remove case code extrinsic field in request header

### DIFF
--- a/lib/cxml/invoice_detail_request/header.rb
+++ b/lib/cxml/invoice_detail_request/header.rb
@@ -2,7 +2,7 @@ module CXML
   module InvoiceDetailRequest
     class Header
       attr_accessor :invoice_id, :operation, :purpose, :invoice_date, :from, :bill_to, :remit_to,
-        :payment_term, :primary_study_contact, :case_code, :vatin, :comments, :invoice_type
+        :payment_term, :primary_study_contact, :vatin, :comments, :invoice_type
 
       def initialize(data={})
         if data.kind_of?(Hash) && !data.empty?
@@ -16,7 +16,6 @@ module CXML
           @payment_term = data[:payment_term]
           @comments = data[:comments]
           @primary_study_contact = data[:primary_study_contact]
-          @case_code = data[:case_code]
           @vatin = data[:vatin]
           @invoice_type = data[:invoice_type]
         end
@@ -37,7 +36,6 @@ module CXML
           h.PaymentTerm('payInNumberOfDays' => payment_term)
           h.Comments(comments, 'xml:lang' => 'en') if comments
           h.Extrinsic(primary_study_contact, 'name' => 'Primary Study Contact') if primary_study_contact
-          h.Extrinsic(case_code, 'name' => 'Case Code') if case_code
           h.Extrinsic(vatin, 'name' => 'VATIN') if vatin
           h.Extrinsic(invoice_type, 'name' => 'Invoice Type') if invoice_type
         end

--- a/spec/invoice_details_request/header_spec.rb
+++ b/spec/invoice_details_request/header_spec.rb
@@ -26,7 +26,6 @@ module CXML
           remit_to: from_attrs.merge(role: 'remitTo', name: 'Bill', email: 'bill@gmail.com', address_id: '123'),
           payment_term: 30,
           primary_study_contact: 'John Doe',
-          case_code: 'A1',
           vatin: '1234',
           comments: 'This is a credit memo',
           invoice_type: 'Credit Memo'
@@ -76,7 +75,6 @@ module CXML
             <PaymentTerm payInNumberOfDays="30"/>
             <Comments xml:lang="en">This is a credit memo</Comments>
             <Extrinsic name="Primary Study Contact">John Doe</Extrinsic>
-            <Extrinsic name="Case Code">A1</Extrinsic>
             <Extrinsic name="VATIN">1234</Extrinsic>
             <Extrinsic name="Invoice Type">Credit Memo</Extrinsic>
           </InvoiceDetailRequestHeader>

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -17,7 +17,7 @@ describe CXML::Request do
       }
     }
 
-    data = { 
+    data = {
       id: 1,
       deployment_mode: 'test',
       header_attrs:{
@@ -28,7 +28,6 @@ describe CXML::Request do
         remit_to: from_attrs.merge(role: 'remitTo', name: 'Bill', email: 'bill@gmail.com', address_id: '123'),
         payment_term: 30,
         primary_study_contact: 'John Doe',
-        case_code: 'A1',
         vatin: '1234',
         comments: 'This is an invoice'
         },
@@ -51,10 +50,10 @@ describe CXML::Request do
           }
         ]
       },
-      summary_attrs: { 
+      summary_attrs: {
         subtotal_amount: 2025,
         subtotal_currency: 'GBP',
-        tax: { 
+        tax: {
           tax_amount: '405',
           tax_currency: 'GBP',
           description: 'total tax',
@@ -116,7 +115,6 @@ describe CXML::Request do
             <PaymentTerm payInNumberOfDays="30"/>
             <Comments xml:lang="en">This is an invoice</Comments>
             <Extrinsic name="Primary Study Contact">John Doe</Extrinsic>
-            <Extrinsic name="Case Code">A1</Extrinsic>
             <Extrinsic name="VATIN">1234</Extrinsic>
           </InvoiceDetailRequestHeader>
           <InvoiceDetailOrder>


### PR DESCRIPTION
This field is no longer needed on the cxml document as it has been replaced by the Distribution node referenced here #17 